### PR TITLE
Add error messages when failing

### DIFF
--- a/cmd/detect/main.go
+++ b/cmd/detect/main.go
@@ -13,7 +13,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-const ErrorMsg = "no Gopkg.toml found at root level"
+const MissingGopkgErrorMsg = "no Gopkg.toml found at root level"
+const MissingBuildpackYmlErrorMsg = "no buildpack.yml found at root level"
+const MissingImportPathErrorMsg = "no import-path found in buildpack.yml"
 const EmptyTargetEnvVariableMsg = "BP_GO_TARGETS set but with empty value"
 
 
@@ -47,7 +49,7 @@ func runDetect(context detect.Detect) (int, error) {
 	if exists, err := helper.FileExists(goPkgFile); err != nil {
 		return detect.FailStatusCode, errors.Wrap(err, fmt.Sprintf("error checking filepath: %s", goPkgFile))
 	} else if !exists {
-		return detect.FailStatusCode, fmt.Errorf(ErrorMsg)
+		return detect.FailStatusCode, fmt.Errorf(MissingGopkgErrorMsg)
 	}
 
 	bpYmlFilePath := filepath.Join(context.Application.Root, "buildpack.yml")
@@ -60,7 +62,7 @@ func runDetect(context detect.Detect) (int, error) {
 		}
 
 		if buildpackYaml.Config.ImportPath == "" {
-			return context.Fail(), nil
+			return context.Fail(), errors.New(MissingImportPathErrorMsg)
 		}
 
 		if environmentTargets, ok := os.LookupEnv("BP_GO_TARGETS"); ok {
@@ -84,5 +86,5 @@ func runDetect(context detect.Detect) (int, error) {
 			},
 		})
 	}
-	return context.Fail(), nil
+	return context.Fail(), errors.New(MissingBuildpackYmlErrorMsg)
 }

--- a/cmd/detect/main_test.go
+++ b/cmd/detect/main_test.go
@@ -33,7 +33,7 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 		it("should fail", func() {
 			code, err := runDetect(factory.Detect)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal(ErrorMsg))
+			Expect(err.Error()).To(Equal(MissingGopkgErrorMsg))
 			Expect(code).To(Equal(detect.FailStatusCode))
 		})
 	})
@@ -44,7 +44,8 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 			test.WriteFile(t, filepath.Join(factory.Detect.Application.Root, "Gopkg.toml"), goPkgString)
 
 			code, err := runDetect(factory.Detect)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(MissingBuildpackYmlErrorMsg))
 			Expect(code).To(Equal(detect.FailStatusCode))
 		})
 	})
@@ -131,7 +132,8 @@ go:
 			test.WriteFile(t, filepath.Join(factory.Detect.Application.Root, "Gopkg.toml"), goPkgString)
 
 			code, err := runDetect(factory.Detect)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(MissingImportPathErrorMsg))
 			Expect(code).To(Equal(detect.FailStatusCode))
 		})
 	})


### PR DESCRIPTION
* Error for missing buildpack.yml
* Error for buildpack.yml with missing `import-path`

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Fixes issue https://github.com/cloudfoundry/dep-cnb/issues/3

* An explanation of the use cases your change solves

Allows for better diagnosis of detection failures

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [] I have made this pull request to the `develop` branch
No develop branch
* [ ] I have added an integration test
