### PR TITLE
Allow the build target to be specified in the buildpack.yml or via BP_GO_TARGETS environment variable 

### DIFF
--- a/dep/dep.go
+++ b/dep/dep.go
@@ -179,7 +179,6 @@ func (c *Contributor) ContributeBinary() error {
 			args = append(args, c.Targets...)
 		}
 
-		layer.Logger.SubsequentLine("%q", args)
 		return c.runner.CustomRun(c.installDir, []string{
 			fmt.Sprintf("GOPATH=%s", c.packagesLayer.Root),
 			fmt.Sprintf("GOBIN=%s", layer.Root),

--- a/dep/mocks_test.go
+++ b/dep/mocks_test.go
@@ -5,10 +5,9 @@
 package dep_test
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockRunner is a mock of Runner interface

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -54,6 +54,21 @@ func testIntegration(t *testing.T, when spec.G, it spec.S) {
 		Expect(app.BuildLogs()).To(MatchRegexp("Dep.*: Contributing to layer"))
 	})
 
+	it("should successfully build a simple app with target", func() {
+		appRoot := filepath.Join("testdata", "simple_app_with_target")
+
+		app, err := dagger.PackBuild(appRoot, goURI, depURI)
+		Expect(err).NotTo(HaveOccurred())
+		defer app.Destroy()
+
+		Expect(app.Start()).To(Succeed())
+		body, _, err := app.HTTPGet("/")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(body).To(ContainSubstring("Hello, World!"))
+
+		Expect(app.BuildLogs()).To(MatchRegexp("Dep.*: Contributing to layer"))
+	})
+
 	it("uses Gopkg.lock as a lockfile for re-builds", func() {
 		appDir := filepath.Join("testdata", "with_lockfile")
 		app, err := dagger.PackBuild(appDir, goURI, depURI)

--- a/integration/testdata/simple_app_with_target/Gopkg.toml
+++ b/integration/testdata/simple_app_with_target/Gopkg.toml
@@ -1,0 +1,4 @@
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/ZiCog/shiny-thing"

--- a/integration/testdata/simple_app_with_target/buildpack.yml
+++ b/integration/testdata/simple_app_with_target/buildpack.yml
@@ -1,0 +1,3 @@
+import-path: hubgit.net/user/app
+go:
+  targets: ["./cmd/site"]

--- a/integration/testdata/simple_app_with_target/cmd/site/site.go
+++ b/integration/testdata/simple_app_with_target/cmd/site/site.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/ZiCog/shiny-thing/foo"
+)
+
+func main() {
+	foo.Do()
+	http.HandleFunc("/", hello)
+	port := "8080"
+	if os.Getenv("PORT") != "" {
+		port = os.Getenv("PORT")
+	}
+	fmt.Println(fmt.Sprintf("listening on %s...", port))
+	err := http.ListenAndServe(":"+port, nil)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func hello(res http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(res, "Hello, World!")
+}


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

### A short explanation of the proposed change:

This allows the buildpack to target a binary that isn't in the root directory of the workspace. 

###  An explanation of the use cases your change solves

The issue is detailed in https://github.com/cloudfoundry/dep-cnb/issues/5

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have added an integration test
