### PR TITLE
buildpack.yml is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Dep Cloud Native Buildpack
+
 To package this buildpack for consumption:
 ```
 $ ./scripts/package.sh
 ```
 This builds the buildpack's Go source using GOOS=linux by default. You can supply another value as the first argument to package.sh.
+
+## Required buildpack.yml
+
+The `dep-cnb` requires a `buildpack.yml` file in the root of the application directory, and must include `go.import-path` for the application:
+
+```yaml
+go:
+  import-path: hubgit.net/user/app
+```
+
+See `integration/testdata/` subfolders for examples.


### PR DESCRIPTION
* A short explanation of the proposed change:

    Currently the README does not document that `buildpack.yml` is required, nor the minimum contents for this required file.

* An explanation of the use cases your change solves

   `pack build` on a project with a `Gopkg.toml` and `Gopkg.lock` file

* [x] I have viewed signed and have submitted the Contributor License Agreement
